### PR TITLE
Develop Flutter WebRTC streaming test app

### DIFF
--- a/webrtc_streaming_test/WEBRTC_IMPLEMENTATION.md
+++ b/webrtc_streaming_test/WEBRTC_IMPLEMENTATION.md
@@ -5,9 +5,9 @@
 Your Flutter app now implements **proper WebRTC streaming** with **SIM number in URL path** as requested:
 
 ### 🔧 **WebRTC Configuration**
-- **Input URL Format**: `ws://47.130.109.65:1078/923244219594`
+- **Input URL Format**: `ws://47.130.109.65:1078`
 - **Protocol**: WebSocket (ws) for WebRTC signaling
-- **SIM Integration**: SIM number included in connection path
+- **SIM Integration**: SIM number included in WebSocket messages
 - **Output URL**: `http://47.130.109.65:8080/923244219594/1.m3u8`
 
 ### 📡 **WebRTC Signaling Implementation**
@@ -21,7 +21,7 @@ Your Flutter app now implements **proper WebRTC streaming** with **SIM number in
 
 ### 1. **Connection Flow**
 ```
-1. App connects to: ws://47.130.109.65:1078/923244219594
+1. App connects to: ws://47.130.109.65:1078
 2. Sends join message with SIM number
 3. Creates WebRTC peer connection
 4. Exchanges offer/answer/ICE candidates
@@ -111,7 +111,7 @@ flutter run
 ```
 
 ### 2. **Your Server is Pre-configured**
-- **Signaling URL**: `ws://47.130.109.65:1078/923244219594`
+- **Signaling URL**: `ws://47.130.109.65:1078`
 - **Output URL**: `http://47.130.109.65:8080/923244219594/1.m3u8`
 - **Default SIM**: `923244219594`
 
@@ -168,7 +168,7 @@ This tests:
 ### 2. **Manual WebSocket Test**
 ```bash
 # Test WebSocket connection with SIM
-wscat -c ws://47.130.109.65:1078/923244219594
+wscat -c ws://47.130.109.65:1078
 ```
 
 ### 3. **Debug Information**
@@ -268,8 +268,8 @@ flutter run
 ```
 
 **Features:**
-- ✅ **WebRTC signaling** to `ws://47.130.109.65:1078/923244219594`
-- ✅ **SIM number integration** in URL path
+- ✅ **WebRTC signaling** to `ws://47.130.109.65:1078`
+- ✅ **SIM number integration** in WebSocket messages
 - ✅ **Real-time streaming** via WebRTC
 - ✅ **Comprehensive debugging** tools
 - ✅ **Connection testing** and monitoring

--- a/webrtc_streaming_test/WEBSOCKET_URL_UPDATE.md
+++ b/webrtc_streaming_test/WEBSOCKET_URL_UPDATE.md
@@ -1,0 +1,141 @@
+# ✅ WebSocket URL Updated
+
+## 🔄 **URL Change Applied**
+
+### **Previous WebSocket URL**:
+```
+ws://47.130.109.65:1078/923244219594
+```
+
+### **New WebSocket URL**:
+```
+ws://47.130.109.65:1078
+```
+
+## 🎯 **What Changed**
+
+### **WebSocket Connection**:
+- **Before**: SIM number included in URL path
+- **After**: Clean base URL without SIM number in path
+
+### **SIM Number Handling**:
+- **Before**: Sent via URL path (`/923244219594`)
+- **After**: Sent via WebSocket message payload
+
+## 🛠️ **Implementation Details**
+
+### **Configuration Update**:
+```dart
+// stream_config.dart - Updated WebRTC signaling URL
+String get webrtcSignalingUrl => 'ws://$inputHost:$inputPort';  
+// Was: 'ws://$inputHost:$inputPort/$simNumber'
+```
+
+### **SIM Number Transmission**:
+The SIM number is now sent in the initial WebSocket message:
+
+```dart
+// webrtc_signaling.dart - SIM number in message payload
+_sendSignalingMessage({
+  'type': 'join',
+  'simNumber': simNumber,           // SIM number here
+  'timestamp': DateTime.now().millisecondsSinceEpoch,
+});
+```
+
+## 📋 **Server Requirements Update**
+
+### **WebSocket Endpoint**:
+Your server should now accept connections at:
+```
+ws://47.130.109.65:1078
+```
+
+### **SIM Number Extraction**:
+Instead of extracting SIM number from URL path, extract it from the message:
+
+```javascript
+// Example server implementation
+wss.on('connection', (ws, req) => {
+  console.log('Client connected to base WebSocket endpoint');
+  
+  ws.on('message', (message) => {
+    const data = JSON.parse(message);
+    
+    if (data.type === 'join') {
+      const simNumber = data.simNumber;  // Extract from message
+      console.log(`Client joined with SIM: ${simNumber}`);
+      // Handle join with SIM number
+    }
+  });
+});
+```
+
+## 🎯 **Benefits of This Change**
+
+### **Simpler URL Structure**:
+- ✅ Clean, standard WebSocket endpoint
+- ✅ No URL path parsing required
+- ✅ More flexible SIM number handling
+
+### **Better Protocol Compliance**:
+- ✅ Standard WebSocket URL format
+- ✅ Data sent via proper message channels
+- ✅ Easier server implementation
+
+### **Enhanced Flexibility**:
+- ✅ SIM number can be changed mid-session
+- ✅ Multiple SIM numbers per connection possible
+- ✅ Additional metadata can be sent easily
+
+## 🚀 **Testing the Update**
+
+### **1. WebSocket Connection Test**:
+```bash
+# Test WebSocket connection (no SIM in URL)
+wscat -c ws://47.130.109.65:1078
+```
+
+### **2. Expected Message Flow**:
+```json
+// Client sends on connection:
+{
+  "type": "join",
+  "simNumber": "923244219594",
+  "timestamp": 1640995200000
+}
+
+// Server should respond:
+{
+  "type": "joined",
+  "simNumber": "923244219594",
+  "message": "Successfully joined"
+}
+```
+
+### **3. App Testing**:
+1. Run the app: `flutter run -d macos`
+2. Tap "Start Stream"
+3. Check debug output for connection to: `ws://47.130.109.65:1078`
+4. Verify SIM number is sent in join message
+
+## 📝 **Documentation Updated**
+
+The following files have been updated to reflect the new URL format:
+- ✅ `stream_config.dart` - WebSocket URL construction
+- ✅ `WEBRTC_IMPLEMENTATION.md` - Documentation examples
+- ✅ Connection testing examples
+- ✅ Server requirement specifications
+
+## ✅ **Current Configuration**
+
+### **WebSocket URLs**:
+- **Signaling**: `ws://47.130.109.65:1078`
+- **Output Stream**: `http://47.130.109.65:8080/923244219594/1.m3u8`
+
+### **SIM Number**: `923244219594`
+- Sent in WebSocket message payload
+- Used in output stream URL path
+- Configurable via app settings
+
+Your WebRTC app now uses the updated WebSocket URL format and will connect to `ws://47.130.109.65:1078` with SIM number sent via message payload! 🎉

--- a/webrtc_streaming_test/lib/stream_config.dart
+++ b/webrtc_streaming_test/lib/stream_config.dart
@@ -28,7 +28,7 @@ class StreamConfig {
   String get outputUrl => 'http://$outputHost:$outputPort/$simNumber/1.m3u8';
   
   // WebRTC signaling URL for streaming
-  String get webrtcSignalingUrl => 'ws://$inputHost:$inputPort/$simNumber';
+  String get webrtcSignalingUrl => 'ws://$inputHost:$inputPort';
   
   // Display-friendly URLs
   String get inputDisplayUrl => '$inputHost:$inputPort';


### PR DESCRIPTION
Fix compilation errors and update WebRTC signaling URL.

This PR resolves multiple compilation errors (e.g., duplicate arguments, type mismatches) that prevented the app from building. It also updates the WebRTC signaling URL to a cleaner base format (`ws://host:port`), with the SIM number now being sent within the WebSocket message payload instead of the URL path.

---

[Open in Web](https://www.cursor.com/agents?id=bc-22f1a558-109b-4441-bb97-4c1eafcaa614) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-22f1a558-109b-4441-bb97-4c1eafcaa614)