### PR TITLE
Build cross-platform HLS video player

### DIFF
--- a/webrtc_streaming_test/lib/hls_player_page.dart
+++ b/webrtc_streaming_test/lib/hls_player_page.dart
@@ -2,8 +2,8 @@ import 'dart:html' as html;
 import 'dart:async';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'web/web_view_factory.dart'
-  if (dart.library.io) 'web_view_factory_stub.dart';
-  if (dart.library.html) 'web/web_view_factory.dart'
+  if (dart.library.io) 'web_view_factory_stub.dart'
+  if (dart.library.html) 'web/web_view_factory.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 import 'package:chewie/chewie.dart';

--- a/webrtc_streaming_test/lib/web/web_view_factory.dart
+++ b/webrtc_streaming_test/lib/web/web_view_factory.dart
@@ -7,6 +7,8 @@ import 'dart:html' as html;
 // This only works on web
 // ignore: undefined_prefixed_name
 import 'dart:ui' as ui;
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:ui_web' as ui_web;
 
 typedef ViewFactory = html.Element Function(int viewId);
 
@@ -15,5 +17,5 @@ void registerWebViewFactory(String viewId, ViewFactory cb) {
   // Register the view factory for the elementId
   // Use the global "platformViewRegistry" if available
   // It works because the compiler understands this name on web
-  ui.platformViewRegistry.registerViewFactory(viewId, cb);
+  ui_web.platformViewRegistry.registerViewFactory(viewId, cb);
 }


### PR DESCRIPTION
Refactor HLS video player and fix external project compilation errors.

The primary HLS video player project received minor cleanup (unused import, updated tests). Crucially, this PR also resolves critical syntax errors in the co-located `webrtc_streaming_test` project. These errors (malformed conditional imports and incorrect `platformViewRegistry` usage) were causing widespread compilation failures and misleading error messages across the shared workspace, preventing successful execution of the HLS video player.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0a1fcbf9-8074-4d44-898b-c8c1af313f13) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0a1fcbf9-8074-4d44-898b-c8c1af313f13)